### PR TITLE
Add dependency snippet and link to Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,20 @@
 
 Utility classes to provide a better experience when running Appium tests in the TestObject cloud.
 
+
+## Installation
+
+TestObject Appium Java API Client is available from
+[Maven Central](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.testobject%22%20AND%20a%3A%22testobject-appium-java-api%22).
+
+    <dependency>
+      <groupId>org.testobject</groupId>
+      <artifactId>testobject-appium-java-api</artifactId>
+      <version>select a version</version>
+      <scope>test</scope>
+    </dependency>
+
+
+## Usage
+
 For an introduction on how to use the utilities, please see our [documentation](https://help.testobject.com/docs/tools/appium/setups/suite-setup/junit/).


### PR DESCRIPTION
Make it easy to add TestObject Appium Java API Client to a project. The Maven Central links makes it easy to discover the current version of this library.